### PR TITLE
fix: line height for bank animation in search bar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@atoapayments/atoa-web-client-sdk",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@atoapayments/atoa-web-client-sdk",
-      "version": "0.0.4",
+      "version": "0.0.6",
       "license": "MIT",
       "devDependencies": {
         "@chenfengyuan/vue-qrcode": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atoapayments/atoa-web-client-sdk",
   "private": false,
-  "version": "0.0.4",
+  "version": "0.0.6",
   "type": "module",
   "description": "Official web client SDK for integrating Atoa Payments into web applications",
   "repository": {

--- a/src/components/rightPane/selectBank/SelectBank.vue
+++ b/src/components/rightPane/selectBank/SelectBank.vue
@@ -281,6 +281,8 @@ function handlePreselectedBank() {
 
 .animated-text {
   margin-left: 4px;
+  display: flex;
+  align-items: center;
 }
 
 .search-input.border-active .placeholder-overlay {

--- a/src/components/sharedComponents/RoundedChip.vue
+++ b/src/components/sharedComponents/RoundedChip.vue
@@ -39,6 +39,9 @@ defineProps({
 .atoa-pay-sdk-chip-text {
   font-size: 12px;
   font-weight: inherit;
+  line-height: normal;
+  display: flex;
+  align-items: center;
 }
 
 .atoa-pay-custom-rounded-chip {


### PR DESCRIPTION
### Changes:
- Remove line height for animated text in search bar.
- Use `align-items` for centering animated text.

### Test Cases:
- Tested on `.min.js` scripts.

- Vanilla .js project
![image](https://github.com/user-attachments/assets/60f42019-52ca-458f-aade-bb2401e52f75)

- Vanilla .js project with css styles
![image (1)](https://github.com/user-attachments/assets/bd09a4bd-ab60-4a61-a7c2-5da5ce05a749)

- Vue project
![image (2)](https://github.com/user-attachments/assets/0f526270-60a8-4b87-a1f9-2f4608aabf3d)

- React project
![image (3)](https://github.com/user-attachments/assets/0216dc6a-f757-41b0-9d0c-f73c3f749f0a)
