### PR TITLE
feat: dynamic bank grid rows, mobile header alignment, short-landscape layout fix

### DIFF
--- a/src/components/PaymentDialog.vue
+++ b/src/components/PaymentDialog.vue
@@ -53,12 +53,15 @@ const customerDetails = inject<CustomerDetails>("customerDetails");
 const errorHandler = inject<ErrorEventHandler>("errorHandler");
 
 const width = ref(window.innerWidth);
+const height = ref(window.innerHeight);
 const isMobileWidth = computed(() => width.value < 1024);
+const isShortViewport = computed(() => height.value < 900);
 
 const rapydToolkitReady = ref(false);
 const cardAuthResponsePromise = ref<Promise<PaymentAuthResponse> | null>(null);
 
 provide("isMobileWidth", isMobileWidth);
+provide("isShortViewport", isShortViewport);
 provide("banksList", banksList);
 provide("paymentRequestDetails", paymentRequestDetails);
 provide("lastPaymentBankDetails", lastPaymentBankDetails);
@@ -145,6 +148,7 @@ async function fetchBanksList() {
 
 const handleResize = () => {
   width.value = window.innerWidth;
+  height.value = window.innerHeight;
 };
 
 onMounted(() => {
@@ -293,7 +297,7 @@ onBeforeUnmount(() => {
     height: auto;
   }
 
-  .left-pane {
+  .content-left {
     display: none;
   }
 

--- a/src/components/rightPane/RightPane.vue
+++ b/src/components/rightPane/RightPane.vue
@@ -732,7 +732,7 @@ const closeOverlay = () => {
   }
 
   .header-title-row {
-    justify-content: center;
+    justify-content: flex-start;
   }
 
   .view-content {

--- a/src/components/rightPane/selectBank/BanksGrid.vue
+++ b/src/components/rightPane/selectBank/BanksGrid.vue
@@ -23,11 +23,19 @@ import type PaymentDetails from "@/core/types/PaymentDetails";
 import BankGridItem from "@/components/rightPane/selectBank/BankGridItem.vue";
 import ViewAllButton from "@/components/rightPane/selectBank/ViewAllButton.vue";
 
-const props = defineProps<{
-  banks: BankData[];
-  selectedType: "personal" | "business";
-  selectedBank?: BankData;
-}>();
+const props = withDefaults(
+  defineProps<{
+    banks: BankData[];
+    selectedType: "personal" | "business";
+    selectedBank?: BankData;
+    maxRows?: number;
+  }>(),
+  {
+    maxRows: 3,
+  },
+);
+
+const totalSlots = computed(() => props.maxRows * 4);
 
 defineEmits<{
   (e: "select", bank: BankData): void;
@@ -65,26 +73,29 @@ const sortedBanksByType = computed(() => {
   ];
 });
 
-// When card payments are enabled and we have >12 banks, show the first 11
-// to make room for the "View all" tile in the 12th slot (3 rows × 4 cols).
+// When card payments are enabled and we have more banks than fit the grid,
+// reserve the last slot for the "View all" tile and show banks up to that slot.
 const banksToDisplay = computed(() => {
   if (
     !showAllBanks.value &&
     cardPaymentEnabled.value &&
-    sortedBanksByType.value.length > 12
+    sortedBanksByType.value.length > totalSlots.value
   ) {
-    return sortedBanksByType.value.slice(0, 11);
+    return sortedBanksByType.value.slice(0, totalSlots.value - 1);
   }
   return sortedBanksByType.value;
 });
 
 const nextFourBanks = computed(() =>
-  sortedBanksByType.value.slice(11, 15),
+  sortedBanksByType.value.slice(totalSlots.value - 1, totalSlots.value + 3),
 );
 
 const showViewAllButton = computed(() => {
   if (showAllBanks.value || !cardPaymentEnabled.value) return false;
-  return sortedBanksByType.value.length > 12 && nextFourBanks.value.length > 0;
+  return (
+    sortedBanksByType.value.length > totalSlots.value &&
+    nextFourBanks.value.length > 0
+  );
 });
 </script>
 

--- a/src/components/rightPane/selectBank/SelectBank.vue
+++ b/src/components/rightPane/selectBank/SelectBank.vue
@@ -24,6 +24,7 @@
         :banks="banks"
         :selected-type="selectedType"
         :selected-bank="selectedBank"
+        :max-rows="gridMaxRows"
         @select="handleBankSelect"
         @show-overlay="(bankData) => emit('showOverlay', bankData)"
       />
@@ -87,8 +88,12 @@ const lastPaymentBankDetails = inject<Ref<LastPaymentBankDetails | undefined>>('
 const paymentDetails = inject<Ref<PaymentDetails>>('paymentRequestDetails');
 const environment = inject<EnvironmentTypeEnum>('environment');
 const isMobileWidth = inject<ComputedRef<boolean>>('isMobileWidth');
+const isShortViewport = inject<ComputedRef<boolean>>('isShortViewport');
 const paymentsService = new PaymentsService();
 const cardPaymentEnabled = computed(() => !!paymentDetails?.value?.options?.cardPaymentEnabled);
+const gridMaxRows = computed(() =>
+  !isMobileWidth?.value && isShortViewport?.value ? 2 : 3,
+);
 
 if (lastPaymentBankDetails) {
   watch(lastPaymentBankDetails, (newValue) => {


### PR DESCRIPTION
## Summary

- **Dynamic bank grid rows on desktop**: bank list switches from 3 rows (12 slots) to 2 rows (8 slots) when viewport height < 900px, so the "Card payment options" button stays visible without scrolling on shorter screens. `PaymentDialog.vue` now provides `isShortViewport`; `BanksGrid.vue` accepts a `maxRows` prop (default 3) and parameterizes its slicing logic via `totalSlots = maxRows × 4`; `SelectBank.vue` injects the flag and passes the computed `gridMaxRows`.
- **Mobile header left-aligned**: `.header-title-row` in `RightPane.vue` mobile media query changed from `justify-content: center` → `flex-start` so the "Pay by bank" title and "Quick and secure" chip left-align with the rest of the mobile layout.
- **Short-landscape layout bug fix**: corrected a broken selector in `PaymentDialog.vue` (`.left-pane` → `.content-left`, the actual class name on `LeftPane.vue`'s root) inside `@media (max-height: 668px) and (orientation: landscape)`. The `display: none` rule was silently a no-op, causing both panes to stack vertically on wide-but-short desktop windows; LeftPane now hides as originally intended.

## Test plan

- [x] Desktop ≥ 900px height: 3-row grid renders (11 banks + View all), card option visible without scrolling.
- [x] Desktop < 900px height: 2-row grid renders (7 banks + View all), card option visible without scrolling; resize across 900px boundary swaps cleanly.
- [x] Mobile (< 1024px width): 3-row grid preserved; "Pay by bank" + chip left-aligned.
- [x] Wide desktop window resized to < 668px tall: LeftPane hides, RightPane fills the dialog (previously: both panes stacked).
- [x] `npx vue-tsc -b` passes (verified locally).