### PR TITLE
fix: center payment details header in mobile dialog

### DIFF
--- a/src/components/rightPane/RightPane.vue
+++ b/src/components/rightPane/RightPane.vue
@@ -735,6 +735,15 @@ const closeOverlay = () => {
     justify-content: flex-start;
   }
 
+  .header-title-row:has(.payment-details-header) {
+    justify-content: center;
+  }
+
+  .sdk-right-pane-header-text:has(.payment-details-header) {
+    padding-left: 48px;
+    box-sizing: border-box;
+  }
+
   .view-content {
     padding: 0;
   }


### PR DESCRIPTION
## Summary
- The "Payment details" title and timestamp in the `PaymentStatusView` header were visually offset to the left on mobile (≤1024px). The close button + flex gap reserved 48px on the right of the header but nothing on the left, so centering inside `.sdk-right-pane-header-left` produced an asymmetric result.
- Adds two scoped CSS rules in `RightPane.vue`'s mobile media query, both gated via `:has(.payment-details-header)` so only `PaymentStatusView` is affected:
  - `justify-content: center` on `.header-title-row` (overrides the existing `flex-start` used by `SelectBankView` for its `<h2>` + `QuickSecureChip`).
  - `padding-left: 48px` + `box-sizing: border-box` on `.sdk-right-pane-header-text` to mirror the right-side reservation (close button 32px + flex gap 16px).

## Test plan
- [x] On mobile viewport (≤1024px), complete a payment to reach `PaymentStatusView` and confirm "Payment details" + timestamp are horizontally centered in the dialog
- [x] Confirm `SelectBankView` header (with `QuickSecureChip`) is unchanged
- [x] Confirm `PaymentInProgressView`, `PaymentOptionsView`, `ExplainerView` headers are unchanged
- [x] Confirm desktop (>1024px) layout is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)